### PR TITLE
[MERGE] Fix the create picking wizard view layout. Show only principal fields and show the fields labels correctly

### DIFF
--- a/crm_claim_rma/wizard/claim_make_picking_view.xml
+++ b/crm_claim_rma/wizard/claim_make_picking_view.xml
@@ -18,7 +18,17 @@
                             <field name="claim_line_dest_location"/>
                         </group>
                         <group string="Select lines for picking" colspan="4">
-                            <field name="claim_line_ids" nolabel="1" colspan="4"/>
+                            <field name="claim_line_ids" nolabel="1" colspan="4">
+                                <tree>
+                                    <field name="claim_id" invisible="1"/>
+                                    <field name="name"/>
+                                    <field name="invoice_line_id"/>
+                                    <field name="product_id"/>
+                                    <field name="state" readonly="True"/>
+                                    <field name="prodlot_id"/>
+                                    <field name="product_returned_quantity"/>
+                                </tree>
+                            </field>
                         </group>
                     </group>
                     <footer>

--- a/crm_claim_rma/wizard/claim_make_picking_view.xml
+++ b/crm_claim_rma/wizard/claim_make_picking_view.xml
@@ -12,11 +12,15 @@
             <field name="model">claim_make_picking.wizard</field>
             <field name="arch" type="xml">
                 <form string="Select exchange lines to add in picking" version="7.0">
-                    <separator string="Locations" colspan="4"/>
-                    <field name="claim_line_source_location" nolabel="1" />
-                    <field name="claim_line_dest_location" nolabel="1" />
-                    <separator string="Select lines for picking" colspan="4"/>
-                    <field name="claim_line_ids" nolabel="1" colspan="4"/>
+                    <group colspan="4">
+                        <group string="Locations" colspan="4">
+                            <field name="claim_line_source_location"/>
+                            <field name="claim_line_dest_location"/>
+                        </group>
+                        <group string="Select lines for picking" colspan="4">
+                            <field name="claim_line_ids" nolabel="1" colspan="4"/>
+                        </group>
+                    </group>
                     <footer>
                         <button name="action_create_picking" string="Create picking" type="object" class="oe_highlight"/>
                         or


### PR DESCRIPTION
This PR refer to task 2927 User Story 807.
Fix the Create picking wizard view.

Screenshots:

- Old view http://goo.gl/OtYE0d
- New view http://goo.gl/4DQ0gX