### PR TITLE
[IMP] get_destination_location method to v8, set_warranty mehtodd cha…

### DIFF
--- a/crm_claim_rma/crm_claim_rma.py
+++ b/crm_claim_rma/crm_claim_rma.py
@@ -340,13 +340,13 @@ class claim_line(models.Model):
                 line.set_warranty()
         return True
 
-    def get_destination_location(self, cr, uid, product_id,
-                                 warehouse_id, context=None):
+    @api.model
+    def get_destination_location(self, product_id, warehouse_id):
         """Compute and return the destination location ID to take
         for a return. Always take 'Supplier' one when return type different
         from company."""
-        wh_obj = self.pool.get('stock.warehouse')
-        wh = wh_obj.browse(cr, uid, warehouse_id, context=context)
+        wh_obj = self.env['stock.warehouse']
+        wh = wh_obj.browse(warehouse_id)
         location_dest_id = wh.lot_stock_id.id
         return location_dest_id
 
@@ -387,14 +387,14 @@ class claim_line(models.Model):
                     'warranty_type': return_type,
                     'location_dest_id': location_dest_id})
 
-    @api.model
+    @api.multi
     def set_warranty(self):
         """ Calculate warranty limit and address """
         for claim_line_brw in self:
             if not (claim_line_brw.product_id and claim_line.invoice_line_id):
                 raise except_orm(
                     _('Error !'),
-                    _('Please set product and invoice.'))
+                    _('Please set product or/and invoice line.'))
             claim_line_brw.set_warranty_return_address()
             claim_line_brw.set_warranty_limit()
         return True

--- a/crm_claim_rma/crm_claim_rma_view.xml
+++ b/crm_claim_rma/crm_claim_rma_view.xml
@@ -177,9 +177,10 @@
         <field name="model">crm.claim</field>
         <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='stage_id']" position="replace">
+            <xpath expr="//field[@name='stage_id']" position="before">
                 <button name="%(action_claim_picking_in)d"
                         string="New Products Return"
+                        class="oe_inline"
                         type="action" target="new"
                         context="{'warehouse_id': warehouse_id,
                             'partner_id': partner_id}"/>
@@ -200,7 +201,6 @@
                             'description': name,
                             'claim_id': id,
                             }"/>
-                <field name="stage_id" widget="statusbar" clickable="True"/>
             </xpath>
             <xpath expr="//page[@string='Claim Description']//group[1]" position="after">
                 <separator colspan="2" string="Product Returns"/>

--- a/crm_claim_rma/wizard/claim_make_picking.py
+++ b/crm_claim_rma/wizard/claim_make_picking.py
@@ -127,14 +127,14 @@ class claim_make_picking(models.TransientModel):
             loc_id = line_location[0]
         return loc_id
 
-    @api.v7
-    def _get_common_partner_from_line(self, cr, uid, line_ids, context):
+    @api.model
+    def _get_common_partner_from_line(self, line_ids):
         """Return the ID of the common partner between all lines. If no common
         partner was found, return False"""
         partner_id = False
-        line_obj = self.pool.get('claim.line')
+        line_obj = self.env['claim.line']
         line_partner = []
-        for line in line_obj.browse(cr, uid, line_ids, context=context):
+        for line in line_obj.browse(line_ids):
             if line.location_dest_id.id not in line_partner:
                 line_partner.append(line.location_dest_id.id)
         # TODO FIX ME, as do when the lines have different directions
@@ -192,8 +192,8 @@ class claim_make_picking(models.TransientModel):
         default=_get_claim_lines,
         string='Claim lines')
 
-    @api.v7
-    def action_cancel(self, cr, uid, ids, context=None):
+    @api.multi
+    def action_cancel(self):
         return {'type': 'ir.actions.act_window_close'}
 
     # If "Create" button pressed
@@ -256,7 +256,6 @@ class claim_make_picking(models.TransientModel):
                       'destination locations, please choose line with a '
                       'same destination location.'))
             self.env['claim.line'].browse(line_ids).auto_set_warranty()
-
             common_dest_partner_id = self._get_common_partner_from_line(
                 line_ids)
             if not common_dest_partner_id:

--- a/crm_claim_rma_config/crm_claim_rma_data.xml
+++ b/crm_claim_rma_config/crm_claim_rma_data.xml
@@ -3,13 +3,13 @@
     <data noupdate="1">
 
     <!-- Claims Type -->
-    <record id="crm_claim_type_supplier" model="crm.claim.type">
-        <field name="name">Supplier</field>
+    <record id="crm_claim_type_customer" model="crm.claim.type">
+        <field name="name">Customer</field>
         <field name="active">1</field>
     </record>
 
-    <record id="crm_claim_type_customer" model="crm.claim.type">
-        <field name="name">Customer</field>
+    <record id="crm_claim_type_supplier" model="crm.claim.type">
+        <field name="name">Supplier</field>
         <field name="active">1</field>
     </record>
 

--- a/crm_rma_advance_location/wizard/claim_make_picking_from_picking.py
+++ b/crm_rma_advance_location/wizard/claim_make_picking_from_picking.py
@@ -47,9 +47,15 @@ class claim_make_picking_from_picking(models.TransientModel):
     # Get default source location
     @api.model
     def _get_source_loc(self):
+        context = self._context
         warehouse_id = self._get_default_warehouse()
-        return warehouse_id.\
-            lot_rma_id.id
+        picking_obj = self.env['stock.picking']
+        picking_id = context.get('active_id')
+        picking_rec = picking_obj.browse(picking_id)
+        if picking_rec.location_dest_id:
+            return picking_rec.location_dest_id.id
+        else:
+            return warehouse_id.lot_rma_id.id
 
     # Get default destination location
     @api.model

--- a/crm_rma_advance_location/wizard/claim_make_picking_from_picking_view.xml
+++ b/crm_rma_advance_location/wizard/claim_make_picking_from_picking_view.xml
@@ -19,12 +19,12 @@
                     <field name="picking_line_ids" nolabel="1" colspan="4"/>
                     <group col="4" colspan="2">
                         <button special="cancel" string="Cancel" name="action_cancel" type="object" icon='gtk-cancel'/>
-                        <button name="action_create_picking_from_picking" string="Create picking" 
+                        <button name="action_create_picking_from_picking" string="Create picking"
                                 icon='gtk-ok' type="object"/>
                     </group>
                 </form>
             </field>
-        </record> 
+        </record>
 
         <record id="action_stock_picking_from_claim_picking" model="ir.actions.act_window">
             <field name="name">Create Incomming Shipment to Stock</field>
@@ -33,7 +33,7 @@
             <field name="src_model">stock.picking</field>
             <field name="view_type">form</field>
             <field name="view_mode">form</field>
-            <field name="target">new</field> 
+            <field name="target">new</field>
             <field name="context">{'picking_type': 'picking_stock'}</field>
         </record>
 
@@ -44,7 +44,7 @@
             <field name="src_model">stock.picking</field>
             <field name="view_type">form</field>
             <field name="view_mode">form</field>
-            <field name="target">new</field> 
+            <field name="target">new</field>
             <field name="context">{'picking_type': 'picking_breakage_loss'}</field>
         </record>
 
@@ -55,7 +55,7 @@
             <field name="src_model">stock.picking</field>
             <field name="view_type">form</field>
             <field name="view_mode">form</field>
-            <field name="target">new</field> 
+            <field name="target">new</field>
             <field name="context">{'picking_type': 'picking_refurbish'}</field>
         </record>
 

--- a/crm_rma_advance_warranty/model/crm_claim_rma.py
+++ b/crm_rma_advance_warranty/model/crm_claim_rma.py
@@ -40,14 +40,13 @@ class claim_line(models.Model):
     @api.one
     @api.model
     def set_warranty_limit(self):
-        date_invoice = self.invoice_line_id.invoice_id.date_invoice
-        if not date_invoice:
+        if not self.date_invoice:
             raise except_orm(
                 _('Error'),
                 _('Cannot find any date for invoice. '
                   'Must be a validated invoice.'))
         warning = _(self.WARRANT_COMMENT['not_define'])
-        date_inv_at_server = datetime.strptime(date_invoice,
+        date_inv_at_server = datetime.strptime(self.date_invoice,
                                                DEFAULT_SERVER_DATE_FORMAT)
         if self.warranty_type == 'supplier':
             if self.prodlot_id:

--- a/crm_rma_claim_make_claim/view/crm_claim_view.xml
+++ b/crm_rma_claim_make_claim/view/crm_claim_view.xml
@@ -7,7 +7,7 @@
             <field name="model">crm.claim</field>
             <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//header" position="inside">
+                <xpath expr="//header/*[1]" position="before">
                     <button name="button_create_rma_vendor"
                         attrs="{'invisible': ['|', ('claim_type', '=', 'supplier')]}"
                         class="oe_inline oe_highlight"


### PR DESCRIPTION
…nged to api.multi because is called from button, improvements in view in header to independence of modules, _get_common_partner_from_line method to v8 because not workinf witj v7, action_cancel method is called from button then is pai.multi, supplier claim_type is created first because in claim by default is filled with first claim type in db, in _get_source_loc method when is created a picking from picking, the source location of new piciking lines is filled with destination location of picking old