### PR TITLE
[IMP] the claim_type is not selection, now is m2o, invisible attribut…

### DIFF
--- a/crm_claim_rma/crm_claim_rma_view.xml
+++ b/crm_claim_rma/crm_claim_rma_view.xml
@@ -252,52 +252,27 @@
         name="Quotations and Sales"
         res_model="sale.order"
         src_model="crm.claim"/>
+
         <act_window
-            id="act_crm_claim_rma_purchase_orders"
-            name="Purchases"
-            res_model="purchase.order"
+        id="act_crm_claim_rma_purchase_orders"
+        name="Purchases"
+        res_model="purchase.order"
         src_model="crm.claim"/>
-<!-- Right side link to invoices -->
+
         <act_window
-        domain="[('type', '=', 'out_invoice')]"
-        id="act_crm_claim_rma_invoice_out"
-        name="Customer Invoices"
-        res_model="account.invoice"
-        src_model="crm.claim"/>
-<!-- Right side link to invoices -->
-        <act_window
-        domain="[('type', '=', 'in_invoice')]"
-        id="act_crm_claim_rma_invoice_in"
-        name="Supplier Invoices"
-        res_model="account.invoice"
-        src_model="crm.claim"/>
-        <act_window
-            domain="[('type', 'in', ('in_invoice', 'out_invoice'))]"
+        domain="[('type', 'in', ('in_invoice', 'out_invoice'))]"
         id="act_crm_claim_rma_invoice"
         name="Invoices"
         res_model="account.invoice"
         src_model="crm.claim"/>
-<!-- Right side link to refunds -->
-        <act_window
-        domain="[('type', '=', 'out_refund')]"
-        id="act_crm_claim_rma_refunds_out"
-        name="Customer Refunds"
-        res_model="account.invoice"
-        src_model="crm.claim"/>
-<!-- Right side link to refunds -->
-        <act_window
-        domain="[('type', '=', 'in_refund')]"
-        id="act_crm_claim_rma_refunds_in"
-        name="Supplier Refunds"
-        res_model="account.invoice"
-        src_model="crm.claim"/>
+
         <act_window
             domain="[('type', 'in', ('in_refund', 'out_refund'))]"
         id="act_crm_claim_rma_refunds"
         name="Refunds"
         res_model="account.invoice"
         src_model="crm.claim"/>
-<!-- Right side link to picking in -->
+
         <act_window
         id="act_crm_claim_rma_picking_in"
         name="Incoming Shipment and Returns"

--- a/crm_claim_rma/crm_claim_rma_view.xml
+++ b/crm_claim_rma/crm_claim_rma_view.xml
@@ -252,6 +252,11 @@
         name="Quotations and Sales"
         res_model="sale.order"
         src_model="crm.claim"/>
+        <act_window
+            id="act_crm_claim_rma_purchase_orders"
+            name="Purchases"
+            res_model="purchase.order"
+        src_model="crm.claim"/>
 <!-- Right side link to invoices -->
         <act_window
         domain="[('type', '=', 'out_invoice')]"
@@ -266,6 +271,12 @@
         name="Supplier Invoices"
         res_model="account.invoice"
         src_model="crm.claim"/>
+        <act_window
+            domain="[('type', 'in', ('in_invoice', 'out_invoice'))]"
+        id="act_crm_claim_rma_invoice"
+        name="Invoices"
+        res_model="account.invoice"
+        src_model="crm.claim"/>
 <!-- Right side link to refunds -->
         <act_window
         domain="[('type', '=', 'out_refund')]"
@@ -278,6 +289,12 @@
         domain="[('type', '=', 'in_refund')]"
         id="act_crm_claim_rma_refunds_in"
         name="Supplier Refunds"
+        res_model="account.invoice"
+        src_model="crm.claim"/>
+        <act_window
+            domain="[('type', 'in', ('in_refund', 'out_refund'))]"
+        id="act_crm_claim_rma_refunds"
+        name="Refunds"
         res_model="account.invoice"
         src_model="crm.claim"/>
 <!-- Right side link to picking in -->
@@ -303,10 +320,6 @@
                     </group>
                 </xpath>
                 <field name="name" position="replace">
-                    <div class="oe_title">
-                        <label for="number" class="oe_edit_only"/>
-                        <h1><field name="number"/></h1>
-                    </div>
                 </field>
                 <field name="date" position="replace">
                 </field>
@@ -314,27 +327,42 @@
                     <field name="date"/>
                 </field>
                 <xpath expr="//sheet[@string='Claims']/group[1]" position="before">
+                    <div class="oe_title">
+                        <label for="number" class="oe_edit_only"/>
+                        <h1><field name="number"/></h1>
+                    </div>
                     <div class="oe_right oe_button_box" name="buttons">
                         <button class="oe_inline oe_stat_button"
                                 name="%(act_crm_claim_rma_sale_orders)d" type="action"
                                 icon="fa-strikethrough"
                                 string="Sales"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False)]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
                                />
                         <button class="oe_inline oe_stat_button"
-                                name="%(act_crm_claim_rma_invoice_in)d" type="action"
-                                string="Invoices"
+                            name="%(act_crm_claim_rma_purchase_orders)d" type="action"
                                 icon="fa-shopping-cart"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['customer','other'])]}"
+                                string="Purchases"
+                                attrs="{'invisible': ['|',('partner_id','=', False)]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
                                />
                         <button class="oe_inline oe_stat_button"
-                                name="%(act_crm_claim_rma_refunds_in)d" type="action"
+                            name="%(act_crm_claim_rma_invoice)d" type="action"
+                                string="Invoices"
+                                icon="fa-pencil-square"
+                                attrs="{'invisible': ['|',('partner_id','=', False)]}"
+                                context="{'search_default_partner_id': [partner_id],
+                                'group_by':'type',
+                                'search_default_user_id':False}"
+                               />
+                        <button class="oe_inline oe_stat_button"
+                                name="%(act_crm_claim_rma_refunds)d" type="action"
                                 string="Refunds"
                                 icon="fa-file-text"
                                 attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['customer','other'])]}"
-                                context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
+                                context="{'search_default_partner_id': [partner_id],
+                                'group_by':'type',
+                                'search_default_user_id':False}"
                                />
                        <button  class="oe_inline oe_stat_button"
                                 icon="fa-reply"


### PR DESCRIPTION
…e was using claim_type like selection, now, the documents (INvoices, Refunds, Sales and Purchases) is grouping and display in all claim_type

Before:
![before claim view 2](https://cloud.githubusercontent.com/assets/7602170/8225966/16637334-1560-11e5-9ba5-d434391d2f9b.png)


After:
![after claim view 2](https://cloud.githubusercontent.com/assets/7602170/8225964/10275eae-1560-11e5-9eca-d53617136512.png)

- Click Returns: Display stock picking receipts to rma
- Click in Purchase: Display Puchases of Partner in the Claim
- Click in Sale: Display Sales of Partner in the Claim

- Click in Invoice: Display Invoices grouping by type (in_invoice and out_invoice). 

![click to invoices](https://cloud.githubusercontent.com/assets/7602170/8226034/beb4a3c8-1560-11e5-8535-c6b28adaed83.png)

- Click in Refund: Display Refunds grouping by type (in_refund and out_refund).

![click to refund](https://cloud.githubusercontent.com/assets/7602170/8226037/c1b21f56-1560-11e5-83d0-2e3d74e34307.png)

