### PR TITLE
[FIX] delivery_address_id field is repeated in crm.claim view

### DIFF
--- a/crm_claim_rma/views/crm_claim_rma.xml
+++ b/crm_claim_rma/views/crm_claim_rma.xml
@@ -348,6 +348,7 @@
                 <xpath expr="//page[@string='Claim Description']//group[1]"
                     position="inside">
                     <field name="pick" string="Pick the product in the store"/>
+                    <field name="invoice_id" domain="['|',('commercial_partner_id','=',partner_id),('partner_id','=',partner_id)]" context="{'create_lines': True}"/>
                     <field name="delivery_address_id"
                         string="Partner delivery address"
                         domain="[('id','child_of',partner_id)]"
@@ -355,8 +356,6 @@
                             'required': [('pick','=', False)]}"
                         context="{'tree_view_ref': 'crm_claim_rma.view_partner_contact_tree',
                             'search_default_parent_id': partner_id}"/>
-                    <field name="invoice_id" domain="['|',('commercial_partner_id','=',partner_id),('partner_id','=',partner_id)]" context="{'create_lines': True}"/>
-                    <field name="delivery_address_id" context="{'tree_view_ref': 'crm_claim_rma.view_partner_contact_tree', 'search_default_parent_id': partner_id}"/>
                 </xpath>
                 <xpath expr="//page[@string='Claim Description']//group[1]"
                     position="after">


### PR DESCRIPTION
- delivery_address_id field is repeated in crm.claim view

**Before**
![campo repetido](https://cloud.githubusercontent.com/assets/7602170/9920256/569d3b5a-5c9c-11e5-9b61-35e413f042cd.png)

**After**
![campo repetido](https://cloud.githubusercontent.com/assets/7602170/9920386/8453ef8e-5c9d-11e5-906f-9f708c8e84fa.png)

