### PR TITLE
[REF] crm_claim_rma: applied OCA changes into crm_claim_rma

### DIFF
--- a/crm_claim_rma/README.rst
+++ b/crm_claim_rma/README.rst
@@ -2,6 +2,7 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
+====================================================
 Management of Return Merchandise Authorization (RMA)
 ====================================================
 
@@ -55,7 +56,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/rma/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/rma/issues/new?body=module:%20crm_claim_rma%0Aversion:%208.0.1.1.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`here <https://github.com/OCA/rma/issues/new?body=module:%20crm_claim_rma%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits

--- a/crm_claim_rma/__openerp__.py
+++ b/crm_claim_rma/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     'name': 'RMA Claim (Product Return Management)',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.1.1',
     'category': 'Generic Modules/CRM & SRM',
     'author': "Akretion, Camptocamp, Eezee-it, MONK Software, Vauxoo, "
               "Odoo Community Association (OCA)",
@@ -44,7 +44,9 @@
         'product_warranty',
     ],
     'data': [
-        'data/crm_claim_rma.xml',
+        'data/ir_sequence_type.xml',
+        'data/crm_case_section.xml',
+        'data/crm_case_categ.xml',
         'views/account_invoice.xml',
         'wizards/claim_make_picking.xml',
         'views/crm_claim.xml',
@@ -54,7 +56,9 @@
         'security/ir.model.access.csv',
     ],
     'demo': [
-        'demo/crm_claim_rma.xml',
+        'demo/account_invoice.xml',
+        'demo/account_invoice_line.xml',
+        'demo/crm_claim.xml',
         'demo/claim_line.xml',
     ],
     'test': [

--- a/crm_claim_rma/data/crm_case_categ.xml
+++ b/crm_claim_rma/data/crm_case_categ.xml
@@ -1,94 +1,73 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data noupdate="1">
-	   <!-- Claims Sequence n° -->
-        <record id="seq_type_claim" model="ir.sequence.type">
-            <field name="name">CRM Claim</field>
-            <field name="code">crm.claim.rma</field>
-        </record>
-
-        <record id="seq_claim" model="ir.sequence">
-            <field name="name">CRM Claim</field>
-            <field name="code">crm.claim.rma</field>
-            <field eval="5" name="padding"/>
-            <field name="prefix">RMA-%(year)s/</field>
-        </record>
-
-        <!-- Claim sections -->
-	   <record model="crm.case.section" id="section_after_sales_service">
-            <field name="name">After Sales Service</field>
-            <field name="code">ASV</field>
-            <field name="parent_id" ref="sales_team.section_sales_department"/>
-        </record>
-
-        <!-- Claim categories -->
-	    <record model="crm.case.categ" id="categ_claim10">
+	    <record id="categ_claim10" model="crm.case.categ">
             <field name="name">No Inventory</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-	    <record model="crm.case.categ" id="categ_claim11">
+	    <record id="categ_claim11" model="crm.case.categ">
             <field name="name">Customer Return</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim12">
+        <record id="categ_claim12" model="crm.case.categ">
             <field name="name">Buyer Cancelled</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim13">
+        <record id="categ_claim13" model="crm.case.categ">
             <field name="name">General Adjustement</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim14">
+        <record id="categ_claim14" model="crm.case.categ">
             <field name="name">Could Not Ship</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim15">
+        <record id="categ_claim15" model="crm.case.categ">
             <field name="name">Different Item</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim16">
+        <record id="categ_claim16" model="crm.case.categ">
             <field name="name">Merchandise Not Received</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim17">
+        <record id="categ_claim17" model="crm.case.categ">
             <field name="name">Merchandise Not As Described</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim18">
+        <record id="categ_claim18" model="crm.case.categ">
             <field name="name">Pricing Error</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim19">
+        <record id="categ_claim19" model="crm.case.categ">
             <field name="name">Shipping Address Undeliverable</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim20">
+        <record id="categ_claim20" model="crm.case.categ">
             <field name="name">Delivered Late by Carrier</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>
         </record>
 
-        <record model="crm.case.categ" id="categ_claim21">
+        <record id="categ_claim21" model="crm.case.categ">
             <field name="name">Missed Fulfilment Promise</field>
             <field name="section_id" ref="section_after_sales_service"/>
             <field name="object_id" search="[('model','=','crm.claim')]" model="ir.model"/>

--- a/crm_claim_rma/data/crm_case_section.xml
+++ b/crm_claim_rma/data/crm_case_section.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+	   <record id="section_after_sales_service" model="crm.case.section">
+            <field name="name">After Sales Service</field>
+            <field name="code">ASV</field>
+            <field name="parent_id" ref="sales_team.section_sales_department"/>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_rma/data/ir_sequence_type.xml
+++ b/crm_claim_rma/data/ir_sequence_type.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="seq_type_claim" model="ir.sequence.type">
+            <field name="name">CRM Claim</field>
+            <field name="code">crm.claim.rma</field>
+        </record>
+
+        <record id="seq_claim" model="ir.sequence">
+            <field name="name">CRM Claim</field>
+            <field name="code">crm.claim.rma</field>
+            <field eval="5" name="padding"/>
+            <field name="prefix">RMA-%(year)s/</field>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_rma/demo/account_invoice.xml
+++ b/crm_claim_rma/demo/account_invoice.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="crm_rma_invoice_001" model="account.invoice">
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="journal_id" ref="account.sales_journal"/>
+            <field name="state">draft</field>
+            <field name="type">out_invoice</field>
+            <field name="account_id" ref="account.a_recv"/>
+            <field name="partner_id" ref="base.res_partner_9"/>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_rma/demo/account_invoice_line.xml
+++ b/crm_claim_rma/demo/account_invoice_line.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data noupdate="1">
-        <record id="crm_rma_invoice_001" model="account.invoice">
-            <field name="currency_id" ref="base.EUR"/>
-            <field name="company_id" ref="base.main_company"/>
-            <field name="journal_id" ref="account.sales_journal"/>
-            <field name="state">draft</field>
-            <field name="type">out_invoice</field>
-            <field name="account_id" ref="account.a_recv"/>
-            <field name="partner_id" ref="base.res_partner_9"/>
-        </record>
-
         <record id="crm_rma_invoice_1_line_1" model="account.invoice.line">
             <field name="product_id" ref="product.product_product_8"/>
             <field name="invoice_id" ref="crm_rma_invoice_001"/>
@@ -27,11 +17,6 @@
             <field name="name">PC Assemble</field>
             <field name="price_unit">450</field>
             <field name="quantity">1</field>
-        </record>
-
-        <record id="crm_claim.crm_claim_6" model="crm.claim">
-            <field name="invoice_id" ref="crm_rma_invoice_001"/>
-            <field name="delivery_address_id" ref="base.res_partner_9"/>
         </record>
     </data>
 </openerp>

--- a/crm_claim_rma/demo/crm_claim.xml
+++ b/crm_claim_rma/demo/crm_claim.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="crm_claim.crm_claim_6" model="crm.claim">
+            <field name="invoice_id" ref="crm_rma_invoice_001"/>
+            <field name="delivery_address_id" ref="base.res_partner_9"/>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_rma/i18n/es.po
+++ b/crm_claim_rma/i18n/es.po
@@ -1,28 +1,18 @@
-#. module: crm_claim_rma
-#: code:addons/crm_claim_rma/crm_claim_rma.py:473
-#, python-format
-msgid "Please set invoice first"
-msgstr ""
-
-#. module: crm_claim_rma
-#: code:addons/crm_claim_rma/crm_claim_rma.py:470
-#, python-format
-msgid "Please set product first"
-msgstr ""# Translation of Odoo Server.
+# Translation of OpenERP Server.
 # This file contains the translation of the following modules:
-# 	* crm_claim_rma
+#   * crm_claim_rma
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 8.0\n"
+"Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2013-12-20 18:21+0000\n"
-"PO-Revision-Date: 2014-01-22 19:38+0000\n"
-"Last-Translator: Pedro Manuel Baeza <pedro.baeza@gmail.com>\n"
+"PO-Revision-Date: 2013-12-20 18:21+0000\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: crm_claim_rma
@@ -464,7 +454,7 @@ msgstr "Documentos generados"
 #. module: crm_claim_rma
 #: help:claim.line,prodlot_id:0
 msgid "The serial/lot of the returned product"
-msgstr "Nº de serie/lote del producto devuelto"
+msgstr "No de Serie/Lote del producto devuelto"
 
 #. module: crm_claim_rma
 #: view:crm.claim:0
@@ -592,8 +582,8 @@ msgstr "Fabricante"
 #. module: crm_claim_rma
 #: field:claim.line,prodlot_id:0
 #: model:ir.model.fields,field_description:crm_claim_rma.field_claim_line_prodlot_id
-msgid "Serial/Lot n°"
-msgstr "N° de serie/lote:"
+msgid "Serial/Lot number"
+msgstr "No. de Serial/Lote"
 
 #. module: crm_claim_rma
 #: help:claim.line,unit_sale_price:0

--- a/crm_claim_rma/models/account_invoice.py
+++ b/crm_claim_rma/models/account_invoice.py
@@ -27,12 +27,10 @@ from openerp import _, api, exceptions, fields, models
 
 
 class AccountInvoice(models.Model):
-    """
-    Account Invoice
-    """
+
     _inherit = "account.invoice"
 
-    claim_id = fields.Many2one('crm.claim', string='Claim', translate=True)
+    claim_id = fields.Many2one('crm.claim', string='Claim')
 
     def _refund_cleanup_lines(self, lines):
         """
@@ -54,7 +52,6 @@ class AccountInvoice(models.Model):
             if not claim_line.refund_line_id:
                 # For each lines replace quantity and add claim_line_id
                 inv_line = claim_line.invoice_line_id
-
                 clean_line = {}
                 for field_name, field in inv_line._all_columns.iteritems():
                     column_type = field.column._type

--- a/crm_claim_rma/models/account_invoice_line.py
+++ b/crm_claim_rma/models/account_invoice_line.py
@@ -27,10 +27,6 @@ from openerp import api, models
 
 class AccountInvoiceLine(models.Model):
 
-    """
-    Account Invoice Line
-    """
-
     _inherit = "account.invoice.line"
 
     @api.model

--- a/crm_claim_rma/models/stock_move.py
+++ b/crm_claim_rma/models/stock_move.py
@@ -25,14 +25,8 @@
 from openerp import api, models
 
 
-# This part concern the case of a wrong picking out. We need to create a new
-# stock_move in a picking already open.
-# In order to don't have to confirm the stock_move we override the create and
-# confirm it at the creation only for this case
 class StockMove(models.Model):
-    """
-    Stock Move
-    """
+
     _name = 'stock.move'
     _inherit = ['stock.move', 'mail.thread']
 

--- a/crm_claim_rma/models/stock_picking.py
+++ b/crm_claim_rma/models/stock_picking.py
@@ -22,19 +22,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import api, fields, models
+from openerp import fields, models
 
 
 class StockPicking(models.Model):
-    """
-    Stock Picking
-    """
+
     _inherit = "stock.picking"
 
     claim_id = fields.Many2one('crm.claim', 'Claim')
-
-    @api.model
-    def create(self, vals):
-        if ('name' not in vals) or (vals.get('name') == '/'):
-            vals['name'] = self.env['ir.sequence'].get(self._name)
-        return super(StockPicking, self).create(vals)

--- a/crm_claim_rma/models/substate_substate.py
+++ b/crm_claim_rma/models/substate_substate.py
@@ -26,6 +26,7 @@ from openerp import fields, models
 
 
 class SubstateSubstate(models.Model):
+
     """
     To precise a state (state=refused; substates= reason 1, 2,...)
     """

--- a/crm_claim_rma/views/claim_line.xml
+++ b/crm_claim_rma/views/claim_line.xml
@@ -105,6 +105,7 @@
                         <group>
                             <h1><field name="number" class="oe_inline"/></h1>
                         </group>
+                        <field name="claim_type" nolabel="1" readonly="1"/>
                     </div>
                     <separator string="Problem" colspan="4"/>
                     <group col="6" colspan="4">

--- a/crm_claim_rma/views/claim_line.xml
+++ b/crm_claim_rma/views/claim_line.xml
@@ -105,13 +105,12 @@
                         <group>
                             <h1><field name="number" class="oe_inline"/></h1>
                         </group>
-                        <field name="claim_type" nolabel="1"/>
                     </div>
                     <separator string="Problem" colspan="4"/>
                     <group col="6" colspan="4">
                         <field name="name" colspan="6"/>
                         <field name="product_id" readonly="1" colspan="6"/>
-                        <field name="prodlot_id" readonly="1" colspan="6"/>
+                        <field name="prodlot_id" colspan="6"/>
                         <field name="claim_origin" colspan="6"/>
                         <field name="claim_diagnosis" colspan="6"/>
                         <field name="priority" colspan="6"/>

--- a/crm_claim_rma/wizards/claim_make_picking.py
+++ b/crm_claim_rma/wizards/claim_make_picking.py
@@ -102,24 +102,18 @@ class ClaimMakePicking(models.TransientModel):
         picking_type = self.env.context.get('picking_type')
         if isinstance(picking_type, int):
             picking_obj = self.env['stock.picking.type']
-            if picking_obj.\
-                    browse(picking_type).\
-                    code == 'incoming':
+            if picking_obj.browse(picking_type).code == 'incoming':
                 picking_type = 'in'
             else:
                 picking_type = 'out'
 
-        move_field = ('move_in_id'
-                      if picking_type == 'in'
-                      else 'move_out_id')
+        move_field = 'move_in_id' if picking_type == 'in' else 'move_out_id'
         domain = [('claim_id', '=', self.env.context['active_id'])]
         lines = self.env['claim.line'].\
             search(domain)
         if lines:
-            domain = domain + [
-                '|', (move_field, '=', False),
-                (move_field + '.state', '=', 'cancel')
-            ]
+            domain = domain + ['|', (move_field, '=', False),
+                               (move_field + '.state', '=', 'cancel')]
             lines = lines.search(domain)
             if not lines:
                 raise exceptions.Warning(
@@ -258,10 +252,9 @@ class ClaimMakePicking(models.TransientModel):
         domain = ("[('picking_type_id', '=', %s), ('partner_id', '=', %s)]" %
                   (picking_type.id, partner_id))
 
-        view_obj = self.env['ir.ui.view']
-        view_id = view_obj.search([('model', '=', 'stock.picking'),
-                                   ('type', '=', 'form'),
-                                   ])[0]
+        view_id = self.env['ir.ui.view'].search(
+            [('model', '=', 'stock.picking'),
+             ('type', '=', 'form')])[0]
         return {
             'name': self._get_picking_name(),
             'view_type': 'form',

--- a/crm_rma_advance_warranty/models/claim_line.py
+++ b/crm_rma_advance_warranty/models/claim_line.py
@@ -109,8 +109,8 @@ class ClaimLine(models.Model):
             return_type = 'company'
 
         location_dest_id = self.get_destination_location(
-            self.product_id.id,
-            self.claim_id.warehouse_id.id).id
+            self.product_id,
+            self.claim_id.warehouse_id).id
 
         self.write({
             'warranty_return_partner': return_address_id,


### PR DESCRIPTION
This proposal changes:

1. Refactor for code indentation
2. Changes ```name_get``` to use now ```display_name```
3. Add ```readonly=1``` for claim_type related field at claim line form view
4. Removes ```readonly=1``` for Serial/Lot number making it writable for the claim line.
5. Includes unit test when an invoice refund is created
6. Correct minor terms for i18n
7. Changes called with models instead of ints in crm_rma_advance_warranty