### PR TITLE
[REF] crm_rma_lot_mass_return: change i18n translations and current c…

### DIFF
--- a/crm_rma_lot_mass_return/i18n/es.po
+++ b/crm_rma_lot_mass_return/i18n/es.po
@@ -161,8 +161,8 @@ msgstr "Escribir el número de serie o lote para buscar el producto."
 
 #. module: crm_rma_lot_mass_return
 #: view:returned.lines.from.serial.wizard:crm_rma_lot_mass_return.view_enter_product
-msgid "You add new returns in claim, are you sure?."
-msgstr "Agregarás nuevas devoluciones en el reclamo, ¿Estás seguro?"
+msgid "You are about to add new lines to the claim, Do you want to continue?."
+msgstr "Se agregarán nuevas líneas a la reclamación, ¿Desea continuar?"
 
 #. module: crm_rma_lot_mass_return
 #: view:returned.lines.from.serial.wizard:crm_rma_lot_mass_return.view_enter_product
@@ -171,8 +171,8 @@ msgstr "Deberías usar ésta ventana"
 
 #. module: crm_rma_lot_mass_return
 #: view:returned.lines.from.serial.wizard:crm_rma_lot_mass_return.view_enter_product
-msgid "_Validate"
-msgstr "_Validar"
+msgid "Add items to the claim"
+msgstr "Añadir productos a la reclamación"
 
 #. module: crm_rma_lot_mass_return
 #: code:addons/crm_rma_lot_mass_return/wizards/returned_lines_from_serial.py:585

--- a/crm_rma_lot_mass_return/wizards/returned_lines_from_serial_wizard.xml
+++ b/crm_rma_lot_mass_return/wizards/returned_lines_from_serial_wizard.xml
@@ -38,9 +38,9 @@
                             <div class="row">
                                 <div class="pull-right" name="buttons">
                                 <button name="add_claim_lines"
-                                    help="Validate the actual picking, it will execute all the validations and the inventory will be affected"
-                                    confirm="You add new returns in claim, are you sure?."
-                                    string="_Validate" colspan="1" type="object" class="oe_highlight"/>
+                                    help="All the valid lines will be added to the claim"
+                                    confirm="You are about to add new lines to the claim, Do you want to continue?."
+                                    string="Add items to the claim" colspan="1" type="object" class="oe_highlight"/>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
…omponents strings

## ```HU #968```
## ```Task #4357```

Current modification looks like:

In the wizard:
![image](https://cloud.githubusercontent.com/assets/2961943/11245947/aa38f796-8de7-11e5-91c3-27ffb43ae0c8.png)

And the confirmation message box before add new lines:
![image](https://cloud.githubusercontent.com/assets/2961943/11245993/e5473d16-8de7-11e5-9ecd-bbc74c8e8faa.png)

