### PR TITLE
[ADD] deadline is a field of odoo core, it is added to here for add i…

### DIFF
--- a/crm_claim_rma/__openerp__.py
+++ b/crm_claim_rma/__openerp__.py
@@ -37,7 +37,6 @@
     'depends': [
         'purchase',
         'sale',
-        'sales_team',
         'stock',
         'crm_claim_rma_code',
         'crm_rma_location',
@@ -55,6 +54,8 @@
         'views/stock_view.xml',
         'views/crm_claim_portal.xml',
         'security/crm_claim_security.xml',
+        'views/res_config.xml',
+        'views/res_company.xml',
         'security/ir.model.access.csv',
     ],
     'demo': [
@@ -62,6 +63,7 @@
         'demo/account_invoice_line.xml',
         'demo/crm_claim.xml',
         'demo/claim_line.xml',
+        'demo/res_company.xml',
     ],
     'test': [
         'test/test_invoice_refund.yml'

--- a/crm_claim_rma/demo/crm_claim.xml
+++ b/crm_claim_rma/demo/crm_claim.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data noupdate="1">
+
         <record id="crm_claim.crm_claim_6" model="crm.claim">
             <field name="invoice_id" ref="crm_rma_invoice_001"/>
             <field name="delivery_address_id" ref="base.res_partner_9"/>
+            <field name="date" eval="time.strftime('%Y-%m-01 10:45:36')"/>
+            <field name="date_deadline" eval="time.strftime('%Y-%m-22')"/>
         </record>
 
         <record id="crm_claim.crm_claim_1" model="crm.claim">
@@ -11,6 +14,33 @@
             <field name="partner_phone">(+886) (02) 4162 2023</field>
             <field name="email_from">demo.portal@yourcompany.example.com</field>
             <field name="pick">1</field>
+            <field name="date" eval="time.strftime('%Y-%m-01 10:45:36')"/>
+            <field name="date_deadline" eval="time.strftime('%Y-%m-22')"/>
+        </record>
+
+        <record id="crm_claim.crm_claim_2" model="crm.claim">
+            <field name="date" eval="time.strftime('%Y-%m-01 10:45:36')"/>
+            <field name="date_deadline" eval="time.strftime('%Y-%m-22')"/>
+        </record>
+
+        <record id="crm_claim.crm_claim_3" model="crm.claim">
+            <field name="date" eval="time.strftime('%Y-%m-01 10:45:36')"/>
+            <field name="date_deadline" eval="time.strftime('%Y-%m-22')"/>
+        </record>
+
+        <record id="crm_claim.crm_claim_4" model="crm.claim">
+            <field name="date" eval="time.strftime('%Y-%m-01 10:45:36')"/>
+            <field name="date_deadline" eval="time.strftime('%Y-%m-22')"/>
+        </record>
+
+        <record id="crm_claim.crm_claim_5" model="crm.claim">
+            <field name="date" eval="time.strftime('%Y-%m-01 10:45:36')"/>
+            <field name="date_deadline" eval="time.strftime('%Y-%m-22')"/>
+        </record>
+
+        <record id="crm_claim.crm_claim_7" model="crm.claim">
+            <field name="date" eval="time.strftime('%Y-%m-01 10:45:36')"/>
+            <field name="date_deadline" eval="time.strftime('%Y-%m-22')"/>
         </record>
 
     </data>

--- a/crm_claim_rma/demo/res_company.xml
+++ b/crm_claim_rma/demo/res_company.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="base.main_company" model="res.company">
+            <field name="limit_days">21</field>
+            <field name="priority_maximum">1</field>
+            <field name="priority_minimum">7</field>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_rma/models/__init__.py
+++ b/crm_claim_rma/models/__init__.py
@@ -31,3 +31,4 @@ from . import product_no_supplier
 from . import stock_move
 from . import stock_picking
 from . import substate_substate
+from . import res_company

--- a/crm_claim_rma/models/res_company.py
+++ b/crm_claim_rma/models/res_company.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Coded by: Yanina Aular <yani@vauxoo.com>
+#    Planified by: Yanina Aular <yani@vauxoo.com>
+#    Audited by: Nhomar Hernandez <nhomar@vauxoo.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import _, api, fields, models
+from openerp.exceptions import ValidationError
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    @api.constrains("priority_maximum", "priority_maximum")
+    def _check_priority_config(self):
+        for company in self:
+            priority_maximum = company.priority_maximum
+            priority_minimum = company.priority_minimum
+            if priority_minimum <= 0 or priority_maximum <= 0:
+                raise ValidationError(
+                    _("Priority maximum and priority_minimum must "
+                      "be greater than zero"))
+            if priority_maximum >= priority_minimum:
+                raise ValidationError(
+                    _("Priority maximum must be less than priority_minimum"))
+
+    @api.constrains("limit_days")
+    def _check_limit_days_config(self):
+        for company in self:
+            if company.limit_days <= 0:
+                raise ValidationError(
+                    _("Limit days must be greater than zero"))
+
+    limit_days = fields.Integer(
+        help="Limit days for resolving a claim since its creation date.")
+    priority_maximum = fields.Integer(
+        help="Priority of a claim should be:\n"
+        "- Very High: Purchase date <= priority maximum range.\n"
+        "- High: priority maximum range < invoice date <= "
+        "priority minimun range")
+    priority_minimum = fields.Integer(
+        help="Priority of a claim should be:\n"
+        "- High: priority maximum range < invoice date "
+        "<= priority minimun range.\n"
+        "- Normal: priority minimun range < invoice date")

--- a/crm_claim_rma/tests/__init__.py
+++ b/crm_claim_rma/tests/__init__.py
@@ -18,4 +18,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+
 from . import test_picking_creation
+from . import test_priority_and_limit_days

--- a/crm_claim_rma/tests/test_priority_and_limit_days.py
+++ b/crm_claim_rma/tests/test_priority_and_limit_days.py
@@ -1,0 +1,207 @@
+# coding: utf-8
+###############################################################################
+#    Module Writen to OpenERP, Open Source Management Solution
+#    Copyright (C) OpenERP Venezuela (<http://www.vauxoo.com>).
+#    All Rights Reserved
+# ############ Credits ########################################################
+#    Coded by: Yanina Aular <yani@vauxoo.com>
+#    Planified by: Yanina Aular <yani@vauxoo.com>
+#    Audited by: Nhomar Hernandez <nhomar@vauxoo.com>
+###############################################################################
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+import datetime
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import ValidationError
+
+
+class TestCreateSimpleClaim(TransactionCase):
+
+    def setUp(self):
+        super(TestCreateSimpleClaim, self).setUp()
+
+    def test_rma_cofiguration(self):
+        # Main Company Configuration
+        company = self.env.ref("base.main_company")
+        company.write(
+            {
+                "limit_days": 10,
+                "priority_maximum": 7,
+                "priority_minimum": 14,
+            })
+
+        # check the data of the company will be
+        # the correct data on the wizard of rma settings
+        rma_config = self.env["rma.config.settings"]
+        data = rma_config.get_default_rma_values()
+        self.assertEqual(data.get("limit_days"), 10)
+        self.assertEqual(data.get("priority_maximum"), 7)
+        self.assertEqual(data.get("priority_minimum"), 14)
+
+        # set the data on the rma settings wizard
+        new_data = {'limit_days': 20,
+                    'priority_maximum': 9,
+                    'priority_minimum': 16,
+                    }
+        rma_config_brw = rma_config.create(new_data)
+        rma_config_brw.execute()
+
+        # verify the new data sets on the wizard in the company
+        self.assertEqual(company.limit_days, 20)
+        self.assertEqual(company.priority_maximum, 9)
+        self.assertEqual(company.priority_minimum, 16)
+
+        new_data = {'limit_days': 20,
+                    'priority_maximum': 18,
+                    'priority_minimum': 16,
+                    }
+        error = ("Priority maximum must be less than priority_minimum")
+        with self.assertRaisesRegexp(ValidationError, error):
+            rma_config_brw = rma_config.create(new_data)
+
+        new_data = {'limit_days': 20,
+                    'priority_maximum': 0,
+                    'priority_minimum': 16,
+                    }
+        error = ("Priority maximum and priority_minimum must "
+                 "be greater than zero")
+        with self.assertRaisesRegexp(ValidationError, error):
+            rma_config_brw = rma_config.create(new_data)
+
+        error = "Limit days must be greater than zero"
+        with self.assertRaisesRegexp(ValidationError, error):
+            company.write(
+                {
+                    "limit_days": 0,
+                })
+
+    def test_limit_days(self):
+        # Main Company Configuration
+        company = self.env.ref("base.main_company")
+        company.write(
+            {
+                "limit_days": 10,
+            })
+
+        # User Administrator
+        user = self.env.ref("base.user_root")
+
+        # Company's user administrator
+        user.write({"company_id": company.id})
+
+        # Create claim
+        claim_id = self.env["crm.claim"].\
+            create({
+                "name": "TEST SIMPLE CLAIM",
+                "claim_type": self.ref("crm_claim_type."
+                                       "crm_claim_type_customer"),
+                "partner_id": self.ref("base.res_partner_16"),
+                "pick": True,
+                "user_id": user.id,
+                "date": "2016-12-01 00:00:00",
+            })
+
+        # Test 1
+        self.assertEqual(claim_id.date_deadline, "2016-12-11")
+
+        # Test 2
+        claim_id.write({"date": "2016-12-10 00:00:00"})
+        self.assertEqual(claim_id.date_deadline, "2016-12-20")
+
+        # Test 3
+        error = "Creation date must be less than deadline"
+        with self.assertRaisesRegexp(ValidationError, error):
+            claim_id.write({"date_deadline": "2016-12-01"})
+
+        # Test 4
+        error = "Creation date must be less than deadline"
+        with self.assertRaisesRegexp(ValidationError, error):
+            claim_id.write({"date_deadline": "2016-12-09"})
+
+        # Test 5
+        error = "Limit days must be greater than zero"
+        with self.assertRaisesRegexp(ValidationError, error):
+            company.write({"limit_days": -1})
+
+        # Test 6
+        error = "Limit days must be greater than zero"
+        with self.assertRaisesRegexp(ValidationError, error):
+            company.write({"limit_days": 0})
+
+    def test_priority(self):
+
+        # Main Company Configuration
+        company = self.env.ref("base.main_company")
+        company.write(
+            {
+                "priority_maximum": 1,
+                "priority_minimum": 7,
+            })
+
+        crm_claim = self.env.ref("crm_claim.crm_claim_6")
+        claim_line_1 = crm_claim.claim_line_ids[0]
+
+        # Sale Invoice
+        invoice = claim_line_1.invoice_line_id.invoice_id
+
+        today = datetime.datetime.now()
+        DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+        # Test 1
+        date_invoice = datetime.datetime.strftime(today, DATETIME_FORMAT)
+        invoice.write({"date_invoice": date_invoice})
+        self.assertEqual(claim_line_1.priority, "3_very_high")
+
+        # Test 2
+        date_invoice = today - datetime.timedelta(days=4)
+        date_invoice = datetime.datetime.strftime(
+            date_invoice, DATETIME_FORMAT)
+        invoice.write({"date_invoice": date_invoice})
+        crm_claim.write({"date": date_invoice})
+        claim_line_1.refresh()
+        claim_line_1._compute_priority()
+        self.assertEqual(claim_line_1.priority, "2_high")
+
+        # Test 3
+        date_invoice = today - datetime.timedelta(days=9)
+        date_invoice = datetime.datetime.strftime(
+            date_invoice, DATETIME_FORMAT)
+        invoice.write({"date_invoice": date_invoice})
+        claim_line_1.refresh()
+        claim_line_1._compute_priority()
+        self.assertEqual(claim_line_1.priority, "1_normal")
+
+        # Test 4
+        invoice.write({"date_invoice": False})
+        claim_line_1.refresh()
+        claim_line_1._compute_priority()
+        self.assertEqual(claim_line_1.priority, "0_not_define")
+
+        # Test 5
+        error = ("Priority maximum and priority_minimum must "
+                 "be greater than zero")
+        with self.assertRaisesRegexp(ValidationError, error):
+            company.write({"priority_maximum": 0})
+
+        # Test 6
+        error = ("Priority maximum and priority_minimum must "
+                 "be greater than zero")
+        with self.assertRaisesRegexp(ValidationError, error):
+            company.write({"priority_maximum": -1})
+
+        # Test 7
+        error = ("Priority maximum must be less than priority_minimum")
+        with self.assertRaisesRegexp(ValidationError, error):
+            company.write({"priority_maximum": 8})

--- a/crm_claim_rma/views/claim_line.xml
+++ b/crm_claim_rma/views/claim_line.xml
@@ -67,7 +67,7 @@
             <field name="name">CRM - Claims Tree</field>
             <field name="model">claim.line</field>
             <field name="arch" type="xml">
-                <tree string="Claim lines">
+                <tree string="Claim lines" colors="red:date_deadline&lt;current_date;">
                     <field name="claim_id" invisible="1"/>
                     <field name="number"/>
                     <field name="state"/>
@@ -82,6 +82,7 @@
                     <field name="product_returned_quantity"/>
                     <field name="claim_origin"/>
                     <field name="claim_diagnosis"/>
+                    <field name="date_deadline"/>
                     <field name="refund_line_id"/>
                     <field name="move_in_id"/>
                     <field name="move_out_id"/>

--- a/crm_claim_rma/views/crm_claim.xml
+++ b/crm_claim_rma/views/crm_claim.xml
@@ -100,7 +100,7 @@
                         <field name="date"/>
                         <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'base.group_sale_salesman_all_leads']}"/>
                         <field name="priority" widget="priority"/>
-                        <field name="date_deadline"/>
+                        <field name="date_deadline" required="1"/>
                         <field name="section_id" groups="base.group_multi_salesteams"/>
                     </group>
                 </xpath>

--- a/crm_claim_rma/views/res_company.xml
+++ b/crm_claim_rma/views/res_company.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="res_company_rma_config_form_view" model="ir.ui.view">
+            <field name="name">res.company.rma.config.form.view</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Overdue Payments']" position="before">
+                    <page string="RMA">
+                        <separator colspan="6" string="Claim Attention Priority"/>
+                        <group name="rma_config" colspan="6">
+                            <group col="2">
+                                <field name="priority_maximum"/>
+                                <newline/>
+                                <field name="priority_minimum"/>
+                            </group>
+                            <group col="4">
+                                <div col="4" class="oe_left">
+                                    <p class="oe_grey">The attention priority of a claim is caculated using invoice date:
+                                        <br/>
+                                        <b>- Very High:</b> invoice date &lt;= priority maximum.
+                                        <br/>
+                                        <b>- High:</b> priority maximum &lt; invoice date &lt;= priority minimun.
+                                        <br/>
+                                        <b>- Normal:</b> priority minimun &lt; invoice date.
+                                    </p>
+                                </div>
+                            </group>
+                        </group>
+                        <separator colspan="6" string="Limit Days"/>
+                        <group colspan="6">
+                            <group col="2">
+                                <field name="limit_days"/>
+                            </group>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/crm_claim_rma/views/res_config.xml
+++ b/crm_claim_rma/views/res_config.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="rma_config_settings_view_form" model="ir.ui.view">
+            <field name="name">rma settings</field>
+            <field name="model">rma.config.settings</field>
+            <field name="arch" type="xml">
+                <form string="Configure Return Merchandise Authorization" class= "oe_form_configuration">
+                    <header>
+                        <button string="Apply" type="object" name="execute" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" type="object" name="cancel" class="oe_link"/>
+                    </header>
+                    <separator string="Sales"/>
+                    <group>
+                        <label for="id" string="Technical Services"/>
+                        <div>
+                            <div>
+                                <b>Limit Days </b>
+                                <field name="limit_days" class="oe_inline"/>
+                                <label string="Days" />
+                            </div>
+                        </div>
+                    </group>
+                    <separator string="Purchase"/>
+                    <group>
+                        <label for="id" string="Claim Attention Priority"/>
+                        <div>
+                            <p>The attention priority of a claim is caculated using invoice date:
+                                <br/>
+                                <b>- Very High:</b> invoice date &lt;= priority maximum.
+                                <br/>
+                                <b>- High:</b> priority maximum &lt; invoice date &lt;= priority minimun.
+                                <br/>
+                                <b>- Normal:</b> priority minimun &lt; invoice date.
+                            </p>
+                            <div>
+                                <b>Priority Maximum </b>
+                                <field name="priority_maximum" class="oe_inline"/>
+                                <label string="Days" />
+                            </div>
+                            <div string="Priority Minimum">
+                                <b>Priority Minimum </b>
+                                <field name="priority_minimum" class="oe_inline"/>
+                                <label string="Days" />
+                            </div>
+                        </div>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record id="action_rma_configuration" model="ir.actions.act_window">
+            <field name="name">Configure Return Merchandise Authorization</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">rma.config.settings</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="rma_config_settings_view_form"/>
+            <field name="target">inline</field>
+            <field name="help" type="html">
+              <p class="oe_view_nocontent_create">
+                Click to configurate parameters of Return Merchandise Authorization.
+              </p>
+            </field>
+        </record>
+
+        <menuitem
+            id="menu_rma_config"
+            name="Return Merchandise Authorization"
+            parent="base.menu_config"
+            action="action_rma_configuration"
+            sequence="55"
+            />
+
+    </data>
+</openerp>

--- a/crm_claim_rma/wizards/__init__.py
+++ b/crm_claim_rma/wizards/__init__.py
@@ -24,3 +24,4 @@
 
 from . import claim_make_picking
 from . import account_invoice_refund
+from . import res_config

--- a/crm_claim_rma/wizards/res_config.py
+++ b/crm_claim_rma/wizards/res_config.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Coded by: Yanina Aular <yani@vauxoo.com>
+#    Planified by: Yanina Aular <yani@vauxoo.com>
+#    Audited by: Nhomar Hernandez <nhomar@vauxoo.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import _, api, fields, models
+from openerp.exceptions import ValidationError
+
+
+class RMAConfigSettings(models.TransientModel):
+    _name = 'rma.config.settings'
+    _inherit = 'res.config.settings'
+
+    @api.constrains("priority_maximum", "priority_maximum")
+    def _check_priority_config(self):
+        for company in self:
+            priority_maximum = company.priority_maximum
+            priority_minimum = company.priority_minimum
+            if priority_minimum <= 0 or priority_maximum <= 0:
+                raise ValidationError(
+                    _("Priority maximum and priority_minimum must "
+                      "be greater than zero"))
+            if priority_maximum >= priority_minimum:
+                raise ValidationError(
+                    _("Priority maximum must be less than priority_minimum"))
+
+    @api.constrains("limit_days")
+    def _check_limit_days_config(self):
+        for company in self:
+            if company.limit_days <= 0:
+                raise ValidationError(
+                    _("Limit days must be greater than zero"))
+
+    limit_days = fields.Integer(
+        help="Limit days for resolving a claim since its creation date.")
+    priority_maximum = fields.Integer(
+        help="Priority of a claim should be:\n"
+        "- Very High: Purchase date <= priority maximum range.\n"
+        "- High: priority maximum range < invoice date <= "
+        "priority minimun range")
+    priority_minimum = fields.Integer(
+        help="Priority of a claim should be:\n"
+        "- High: priority maximum range < invoice date "
+        "<= priority minimun range.\n"
+        "- Normal: priority minimun range < invoice date")
+
+    @api.multi
+    def get_default_rma_values(self):
+        """
+        Get the current company rma configuration and
+        show into the config
+        wizard.
+        @return dictionary with the values to display.
+        """
+        company = self.env.user.company_id
+        return {
+            "limit_days": company.limit_days,
+            "priority_maximum": company.priority_maximum,
+            "priority_minimum": company.priority_minimum,
+        }
+
+    @api.multi
+    def set_rma_config(self):
+        """
+        Write the rma configuratin in the wizard into the company model.
+        @return True
+        """
+        company = self.env.user.company_id
+        for rma_config in self:
+            company.write({
+                "limit_days": rma_config.limit_days,
+                "priority_maximum": rma_config.priority_maximum,
+                "priority_minimum": rma_config.priority_minimum,
+            })
+        return True

--- a/crm_rma_claim_make_claim/models/claim_line.py
+++ b/crm_rma_claim_make_claim/models/claim_line.py
@@ -20,6 +20,7 @@
 #
 ##############################################################################
 
+import datetime
 from openerp import _, api, fields, models
 from openerp.exceptions import Warning as UserError
 
@@ -69,6 +70,14 @@ class ClaimLine(models.Model):
                                                 claim_line_parent.
                                                 supplier_id.id)])
             if not claim_supplier:
+                today_datetime = datetime.datetime.now()
+                today = datetime.datetime.strftime(
+                    today_datetime, "%Y-%m-%d %H:%M:%S")
+                deadline_datetime = today_datetime + \
+                    datetime.timedelta(
+                        days=self.env.user.company_id.limit_days)
+                deadline = datetime.datetime.strftime(
+                    deadline_datetime, "%Y-%m-%d")
                 claim_supplier = claim_obj.create({
                     'name': 'Supplier Claim',
                     'code': '/',
@@ -79,6 +88,10 @@ class ClaimLine(models.Model):
                     'email_from': claim_line_parent.supplier_id.email,
                     'partner_phone': claim_line_parent.supplier_id.phone,
                     'delivery_address_id': claim_line_parent.supplier_id.id,
+                    'user_id': self.env.user.id,
+                    'company_id': self.env.user.company_id.id,
+                    'date': today,
+                    'date_deadline': deadline,
                 })
             elif len(claim_supplier) > 1:
                 # search the supplier claim with less lines

--- a/crm_rma_claim_make_claim/tests/test_crm_rma_claim_make_claim.py
+++ b/crm_rma_claim_make_claim/tests/test_crm_rma_claim_make_claim.py
@@ -19,6 +19,7 @@
 #
 ##############################################################################
 
+import datetime
 from openerp.tests.common import TransactionCase
 
 
@@ -45,6 +46,13 @@ class TestCrmRmaClaimMakeClaim(TransactionCase):
         on include_lines parameter
         """
 
+        today_datetime = datetime.datetime.now()
+        today = datetime.datetime.strftime(
+            today_datetime, "%Y-%m-%d %H:%M:%S")
+        deadline_datetime = today_datetime + \
+            datetime.timedelta(days=self.env.user.company_id.limit_days)
+        deadline = datetime.datetime.strftime(
+            deadline_datetime, "%Y-%m-%d")
         return self.env['crm.claim'].\
             create({
                 'name': 'Test Claim for %s' % (self.customer_id.name),
@@ -52,6 +60,10 @@ class TestCrmRmaClaimMakeClaim(TransactionCase):
                 'partner_id': self.customer_id.id,
                 'pick': True,
                 'code': '/',
+                'user_id': self.env.user.id,
+                'company_id': self.env.user.company_id.id,
+                'date': today,
+                'date_deadline': deadline,
                 'claim_line_ids': [(0, 0, {
                     'supplier_id': self.supplier_id_1.id,
                     'claim_origin': u'damaged',


### PR DESCRIPTION
…t a help and then make it a functional field. It is added a menu for rma settings for calculate priority and deadline on claim.

Resolve https://github.com/Vauxoo/rma/issues/97

**Demostration:**
Video1: https://youtu.be/JLC5Kdhw5w8
Video2: https://youtu.be/f5q4_WEFA9g


1. If today date is major that deadline, the products should be shown in red color in claim line tree view
(claim.line model).
![claim line red](https://cloud.githubusercontent.com/assets/7602170/12757424/2fc056e0-c9aa-11e5-99df-92bc343d3f57.jpg)

2. The order in claim line tree view should be by priority.
![order claim line](https://cloud.githubusercontent.com/assets/7602170/12755829/3fccf5cc-c9a3-11e5-8058-76401f5cd4c6.jpg)

3. Create settings menu (Return Merchandise Authorization) with two sections.

   - Sales.
      - Technical Services.
   - Purchases.
![setting rma](https://cloud.githubusercontent.com/assets/7602170/12521054/6629be62-c11a-11e5-9105-f78204220a49.jpg)

4. RMA Page in the company form. 
![company](https://cloud.githubusercontent.com/assets/7602170/12533567/b0fee480-c205-11e5-86bc-54269f75abda.jpg)

5. If today date is major that deadline, the products should be shown in red color in claim line tree view
(claim.line model).
 
6. Deadline field of claim (crm.claim): 

   - Deadline should be a compute field, the compute will make when date field is changed. With the compute deadline, the customer can know deadline at moment that the claim is created. 
   - The formula for calculating the deadline should be calculated from the date the claim and the number of days that can be configured in the company called limit_days. i.e. **date + limit_days = deadline**. By example: 
      - date = 02/02/2016
      - limit_days = 21 days
      - deadline = 02/02/2016 + 21 days = 02/23/2016
  - Deadline is required. 
  - The deadline will be not minor that creation date of claim.
   - RMA manager user can modify the deadline.