### PR TITLE
[IMP] Tranfers missing product in demo sale order

### DIFF
--- a/crm_rma_lot_mass_return/demo/transfer_details.xml
+++ b/crm_rma_lot_mass_return/demo/transfer_details.xml
@@ -187,6 +187,16 @@
             <field name="lot_id" ref="lot_purchase_wizard_rma_item_4"/>
         </record>
 
+        <record id="transfer_sale_wizard_rma_item_8" model="stock.transfer_details_items">
+            <field name="transfer_id" ref="transfer_sale_wizard_rma"/>
+            <field name="product_id" ref="product.product_product_8"/>
+            <field name="product_uom_id" ref="product.product_uom_unit"/>
+            <field name="quantity">1</field>
+            <field name="sourceloc_id"  ref="stock.stock_location_stock"/>
+            <field name="destinationloc_id" ref="stock.stock_location_customers"/>
+            <field name="lot_id" eval="False"/>
+        </record>
+
         <!-- Make transfer of product -->
         <function model="stock.picking" name="action_assign">
             <value eval="obj(ref('so_wizard_rma_1')).picking_ids[0].id" model="sale.order"/>


### PR DESCRIPTION
Tranfers missing product in demo sale order and the quant of product remains in Customers Location because in RMA, when the claim is registrered, the product should be in Customers Location

![falta transferir](https://cloud.githubusercontent.com/assets/7602170/14301545/87ecd408-fb62-11e5-9dba-eefa2e238656.jpg)
