### PR TITLE
[FIX] error when there is a new claim type and it is not customer or supplier

### DIFF
--- a/crm_rma_lot_mass_return/wizards/returned_lines_from_serial.py
+++ b/crm_rma_lot_mass_return/wizards/returned_lines_from_serial.py
@@ -264,9 +264,8 @@ class ReturnedLinesFromSerial(models.TransientModel):
             element_searched = False
             if invoice_ids:
 
-                if supplier_claim_type == current_claim_type:
-                    invoice_field = 'supplier_invoice_line_id'
-                elif customer_claim_type == current_claim_type:
+                invoice_field = 'supplier_invoice_line_id'
+                if customer_claim_type == current_claim_type:
                     invoice_field = 'invoice_line_id'
 
                 for inv in invoice_ids:


### PR DESCRIPTION
### FIX error when there is new claim type that it is not customer or supplier.

``` python 
    method_res = getattr(self._model, method)(*args, context=self._context)
  File "/media/yanina/Extra Drive 1/vauxoo/public_addons/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/media/yanina/Extra Drive 1/vauxoo/public_addons/odoo/openerp/api.py", line 399, in old_api
    result = method(recs, *args, **kwargs)
  File "/home/yanina/vauxoo/public_addons/rma/crm_rma_lot_mass_return/wizards/returned_lines_from_serial.py", line 382, in onchange_load_products
    self._get_lots_from_scan_data(input_data)
  File "/home/yanina/vauxoo/public_addons/rma/crm_rma_lot_mass_return/wizards/returned_lines_from_serial.py", line 278, in _get_lots_from_scan_data
    search([(invoice_field, '=',
UnboundLocalError: local variable 'invoice_field' referenced before assignment
```