### PR TITLE
[FIX] when a supplier claim line is created from customer claim line, the quantity in the customer claim line is not copied into supplier claim line

### DIFF
--- a/crm_rma_claim_make_claim/models/claim_line.py
+++ b/crm_rma_claim_make_claim/models/claim_line.py
@@ -126,6 +126,8 @@ class ClaimLine(models.Model):
                     'claim_origin': claim_line_parent.claim_origin,
                     'prodlot_id': claim_line_parent.prodlot_id.id,
                     'priority': claim_line_parent.priority,
+                    'product_returned_quantity':
+                    claim_line_parent.product_returned_quantity,
                 })
             good_lines += [claim_line_supplier_new.id]
 


### PR DESCRIPTION
[FIX] when a supplier claim line is created from customer claim line, the quantity in the customer claim line is not copied into supplier claim line