### PR TITLE
[FIX] W7908(missing-newline-extrafiles), i18n/es_MX.po and i18n/es_VE.po Missing newline

### DIFF
--- a/crm_claim_product_supplier/i18n/es_MX.po
+++ b/crm_claim_product_supplier/i18n/es_MX.po
@@ -19,3 +19,4 @@ msgstr ""
 #: help:claim.line,supplier_id:0
 msgid "Supplier of good in claim"
 msgstr "Proveedor de productos en el reclamo"
+

--- a/crm_claim_product_supplier/i18n/es_VE.po
+++ b/crm_claim_product_supplier/i18n/es_VE.po
@@ -19,3 +19,4 @@ msgstr ""
 #: help:claim.line,supplier_id:0
 msgid "Supplier of good in claim"
 msgstr "Proveedor de productos en el reclamo"
+


### PR DESCRIPTION
### Issue: https://github.com/Vauxoo/rma/issues/116 
### FIX
``` python

************* Module crm_claim_product_supplier
crm_claim_product_supplier/__init__.py:1: [W7908(missing-newline-extrafiles), ] i18n/es_MX.po Missing newline
crm_claim_product_supplier/__init__.py:1: [W7908(missing-newline-extrafiles), ] i18n/es_VE.po Missing newline

```